### PR TITLE
fix runtime version due to vercel issue (must be at node v18)

### DIFF
--- a/.github/workflows/preview-pipeline.yml
+++ b/.github/workflows/preview-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
     needs: preview_pipeline
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Install Vercel
         run: npm install --global vercel
       - name: Deploy to preview

--- a/.github/workflows/production-pipeline.yml
+++ b/.github/workflows/production-pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     needs: production_pipeline
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Install Vercel
         run: npm install --global vercel
       - name: Deploy to production


### PR DESCRIPTION
This pull request includes a couple of changes to the GitHub workflow configuration files to ensure compatibility and stability.

Workflow configuration updates:

* [`.github/workflows/preview-pipeline.yml`](diffhunk://#diff-192552cb0aec7b8511c98f9deec5228abe55239ef3e3214e6a1013cb8ddbdfccL22-R22): Downgraded the `actions/checkout` version from `v4` to `v3`.
* [`.github/workflows/production-pipeline.yml`](diffhunk://#diff-d127a357f1ec57bafc027c20be6919e82bf236183b9bb97f176b37d1b91da9c4L24-R24): Downgraded the `actions/checkout` version from `v4` to `v3`.