### PR TITLE
fix runtime version due to vercel issue (must be at node v18) part 2

### DIFF
--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
       - name: Cache node modules
         uses: actions/cache@v4
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
       - name: Cache node modules
         uses: actions/cache@v4
         with:
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
       - name: Cache node modules
         uses: actions/cache@v4
         with:
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
       - name: Cache node modules
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/base-ci.yml` file to update the Node.js version used in the CI pipeline. The most important change is the downgrade of the Node.js version from 20 to 18 across multiple job steps.

Node.js version update:

* [`.github/workflows/base-ci.yml`](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL23-R23): Changed the `node-version` from 20 to 18 in the `Set up Node.js` step for all job configurations. [[1]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL23-R23) [[2]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL44-R44) [[3]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL67-R67) [[4]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL88-R88)