### PR TITLE
downgrade everything

### DIFF
--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: npm-cache-${{ hashFiles('package-lock.json') }}
@@ -37,13 +37,13 @@ jobs:
     needs: install_dependencies
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: npm-cache-${{ hashFiles('package-lock.json') }}
@@ -60,13 +60,13 @@ jobs:
     needs: install_dependencies
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: npm-cache-${{ hashFiles('package-lock.json') }}
@@ -81,13 +81,13 @@ jobs:
     needs: install_dependencies
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: npm-cache-${{ hashFiles('package-lock.json') }}
@@ -102,7 +102,7 @@ jobs:
     needs: [run_tests, run_lint, run_typecheck]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         with:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/base-ci.yml` file. The changes involve downgrading the versions of several GitHub Actions used in the CI pipeline.

Changes to GitHub Actions versions:

* Updated the `actions/checkout` action from version `v4` to `v3`. (`.github/workflows/base-ci.yml` - [[1]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL19-R25) [[2]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL40-R46) [[3]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL63-R69) [[4]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL84-R90) [[5]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL105-R105)
* Updated the `actions/setup-node` action from version `v4` to `v3`. (`.github/workflows/base-ci.yml` - [[1]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL19-R25) [[2]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL40-R46) [[3]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL63-R69) [[4]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL84-R90)
* Updated the `actions/cache` action from version `v4` to `v3`. (`.github/workflows/base-ci.yml` - [[1]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL19-R25) [[2]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL40-R46) [[3]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL63-R69) [[4]](diffhunk://#diff-65e6701c48d2fdb39d80c67fa4b284b4e21e90b8517dc13923482c58601c3b4fL84-R90)