### PR TITLE
Forcing node 18

### DIFF
--- a/.github/workflows/preview-pipeline.yml
+++ b/.github/workflows/preview-pipeline.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Vercel
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
         run: npm install --global vercel
       - name: Deploy to preview
         run: |

--- a/.github/workflows/production-pipeline.yml
+++ b/.github/workflows/production-pipeline.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Vercel
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
         run: npm install --global vercel
       - name: Deploy to production
         run: |


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to ensure compatibility with Node.js version 18.

Workflow updates:

* [`.github/workflows/preview-pipeline.yml`](diffhunk://#diff-192552cb0aec7b8511c98f9deec5228abe55239ef3e3214e6a1013cb8ddbdfccR24-R26): Added `actions/setup-node@v3` to install Node.js version 18 before running Vercel installation.
* [`.github/workflows/production-pipeline.yml`](diffhunk://#diff-d127a357f1ec57bafc027c20be6919e82bf236183b9bb97f176b37d1b91da9c4R26-R28): Added `actions/setup-node@v3` to install Node.js version 18 before running Vercel installation.