### PR TITLE
Forcing node 18 part 2

### DIFF
--- a/.github/workflows/preview-pipeline.yml
+++ b/.github/workflows/preview-pipeline.yml
@@ -21,11 +21,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Vercel
-        uses: actions/setup-node@v3
         with:
           node-version: 18
         run: npm install --global vercel
       - name: Deploy to preview
+        with:
+          node-version: 18
         run: |
           vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/production-pipeline.yml
+++ b/.github/workflows/production-pipeline.yml
@@ -23,11 +23,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Vercel
-        uses: actions/setup-node@v3
         with:
           node-version: 18
         run: npm install --global vercel
       - name: Deploy to production
+        with:
+          node-version: 18
         run: |
           vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflows for both preview and production pipelines. The changes ensure that the correct Node.js version is specified directly within the deployment steps.

Changes in `.github/workflows/preview-pipeline.yml`:

* Removed the `actions/setup-node@v3` step and added the `node-version: 18` configuration directly in the deployment step. (`[.github/workflows/preview-pipeline.ymlL24-R29](diffhunk://#diff-192552cb0aec7b8511c98f9deec5228abe55239ef3e3214e6a1013cb8ddbdfccL24-R29)`)

Changes in `.github/workflows/production-pipeline.yml`:

* Removed the `actions/setup-node@v3` step and added the `node-version: 18` configuration directly in the deployment step. (`[.github/workflows/production-pipeline.ymlL26-R31](diffhunk://#diff-d127a357f1ec57bafc027c20be6919e82bf236183b9bb97f176b37d1b91da9c4L26-R31)`)